### PR TITLE
Fix "too long" warning for last line without newline

### DIFF
--- a/src/library/daemon-config.c
+++ b/src/library/daemon-config.c
@@ -256,11 +256,17 @@ static char *get_line(FILE *f, char *buf, unsigned size, int *lineno,
 			too_long = 0;
 			*lineno = *lineno + 1;
 		} else {
-			// If a line is too long skip it.
-			// Only output 1 warning
-			if (!too_long)
+			if (!too_long) {
+				size_t len = strlen(buf);
+				if (len < size - 1) {
+					// last line without trailing newline
+					return buf;
+				}
+				// If a line is too long skip it.
+				// Only output 1 warning
 				msg(LOG_ERR, "Skipping line %d in %s: too long",
 					*lineno, file);
+			}
 			too_long = 1;
 		}
 	}


### PR DESCRIPTION
Fixes:

    # sed -i "/^integrity/d" /etc/fapolicyd/fapolicyd.conf
    # echo -n "integrity = sha256" >> /etc/fapolicyd/fapolicyd.conf
    # fapolicyd
    ...
    fapolicyd[1977]: Skipping line 21 in /etc/fapolicyd/fapolicyd.conf: too long