### PR TITLE
Add readonly mode for trust database initialization

### DIFF
--- a/src/library/database.c
+++ b/src/library/database.c
@@ -37,6 +37,7 @@
 #include <ctype.h>
 #include <openssl/sha.h>
 #include <signal.h>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/mman.h>
@@ -112,6 +113,8 @@ extern atomic_bool stop;
 extern atomic_bool needs_flush;
 extern atomic_bool reload_rules;
 
+static int db_lock_fd = -1;
+static char *db_lock_path = DB_LOCK;
 
 static int is_link(const char *path)
 {
@@ -1774,6 +1777,57 @@ void unlock_rule(void) {
 }
 
 /*
+* Lock database to prevent update when there's another reader
+ */
+int lock_db(conf_t *config, int write) {
+	char err_buff[BUFFER_SIZE];
+	int op;
+
+	db_lock_fd  = open(db_lock_path, O_WRONLY, 0);
+	if (db_lock_fd < 0 && errno == ENOENT) {
+		if ((db_lock_fd  = open(db_lock_path, O_CREAT | O_WRONLY, 0660)) < 0) {
+			msg(LOG_ERR, "Can't lock the database");
+			return -1;
+		}
+		if (chown(db_lock_path, config->uid, config->gid)) {
+			msg(LOG_ERR, "Failed to fix ownership of lock file %s (%s)",
+			    db_lock_path, strerror_r(errno, err_buff, BUFFER_SIZE));
+			return -1;
+		}
+
+	}
+        if (db_lock_fd < 0) {
+                msg(LOG_ERR, "Failed to open lock file %s: %s",
+                    db_lock_path, strerror_r(errno, err_buff, BUFFER_SIZE));
+                return -1;
+        }
+
+        op = write ? LOCK_EX : LOCK_SH;
+
+        if (flock(db_lock_fd, op) < 0) {
+                msg(LOG_ERR, "Failed to acquire lock on %s: %s",
+                    db_lock_path, strerror(errno));
+		sleep(5);
+                close(db_lock_fd);
+                db_lock_fd = -1;
+                return -1;
+        }
+
+        return 0;
+}
+
+void release_db_lock(void)
+{
+        if (db_lock_fd >= 0) {
+                flock(db_lock_fd, LOCK_UN);
+                close(db_lock_fd);
+                db_lock_fd = -1;
+        }
+}
+
+
+
+/*
  * This function reloads updated backend db into our internal database.
  * It returns 0 on success and non-zero on error.
  */
@@ -1815,6 +1869,7 @@ static int update_database(conf_t *config)
 
 	unlock_update_thread();
 	mdb_env_sync(env, 1);
+	release_db_lock();
 
 	if (rc) {
 		msg(LOG_ERR, "Failed to create the trust database (%d)", rc);
@@ -2186,18 +2241,23 @@ int walk_database_start(conf_t *config)
 		return 1;
 	}
 
+	if (lock_db(config, 0) < 0)
+		printf("Cannot acquire database lock, continue without locking");
+
 	// Position to the first entry
 	mdb_txn_begin(env, NULL, MDB_RDONLY, &lt_txn);
 
 	if ((rc = open_dbi(lt_txn))) {
 		puts(mdb_strerror(rc));
 		abort_transaction(lt_txn);
+		release_db_lock();
 		return 1;
 	}
 
 	if ((rc = mdb_cursor_open(lt_txn, dbi, &lt_cursor))) {
 		puts(mdb_strerror(rc));
 		abort_transaction(lt_txn);
+		release_db_lock();
 		return 1;
 	}
 
@@ -2236,4 +2296,6 @@ void walk_database_finish(void)
 	mdb_cursor_close(lt_cursor);
 	abort_transaction(lt_txn);
 	close_db(0);
+	release_db_lock();
+
 }

--- a/src/library/database.c
+++ b/src/library/database.c
@@ -340,12 +340,15 @@ static int grow_map_after_full(conf_t *config)
 }
 
 
-static int init_db(const conf_t *config)
+static int init_db(const conf_t *config, int read_only)
 {
 	unsigned int flags = MDB_MAPASYNC|MDB_NOSYNC;
 #ifndef DEBUG
 	flags |= MDB_WRITEMAP;
 #endif
+	if (read_only)
+		flags = MDB_NOSYNC|MDB_RDONLY|MDB_NOLOCK;
+
 	if (mdb_env_create(&env)) {
 		/* env not allocated on failure, but ensure it's NULL */
 		env = NULL;
@@ -1425,7 +1428,7 @@ int init_database(conf_t *config)
 		msg(LOG_INFO, "autosize: map size recomputed to %u MiB",
 		    config->db_max_size);
 
-	if ((rc = init_db(config))) {
+	if ((rc = init_db(config, 0))) {
 		msg(LOG_ERR, "Cannot open the trust database, init_db() (%d)",
 		    rc);
 		return rc;
@@ -1888,7 +1891,7 @@ static void do_reload_db(conf_t* config)
 			mdb_env_close(env);
 			env = NULL;
 
-			if ((rc = init_db(config))) {
+			if ((rc = init_db(config, 0))) {
 				msg(LOG_ERR,
 			     "Cannot open the trust database, init_db() (%d)",
 					rc);
@@ -2174,7 +2177,7 @@ int walk_database_start(conf_t *config)
 	int rc;
 
 	// Initialize the database
-	if (init_db(config)) {
+	if (init_db(config, 1)) {
 		printf("Cannot open the trust database\n");
 		return 1;
 	}

--- a/src/library/paths.h
+++ b/src/library/paths.h
@@ -33,6 +33,7 @@
 #define TRUST_FILE_PATH "/etc/fapolicyd/fapolicyd.trust"
 #define DB_DIR          "/var/lib/fapolicyd"
 #define DB_NAME         "trust.db"
+#define DB_LOCK         "/var/lib/fapolicyd/db.lock"
 #define REPORT          "/var/log/fapolicyd-access.log"
 #define RUN_DIR         "/run/fapolicyd/"
 #define STAT_REPORT     "/run/fapolicyd/fapolicyd.state"


### PR DESCRIPTION
init_db() accepts a read_only parameter now. This allows database walking operations to access the trust database without acquiring write locks. e.g. in `fapolicyd-cli --check-trustdb`